### PR TITLE
bug: Onboarding page next and prev button overlapping elements in low height displays

### DIFF
--- a/app/app/onboarding/page.tsx
+++ b/app/app/onboarding/page.tsx
@@ -25,7 +25,7 @@ const OnboardingPage = async (
 	}
 
 	return (
-		<div className="h-full w-full relative">
+		<div className="h-full min-h-dvh w-full relative">
 			<BrainAnimation onboardingStep={step} />
 
 			{step === OnboardingStep.WELCOME && <Welcome />}

--- a/components/onboarding/About.tsx
+++ b/components/onboarding/About.tsx
@@ -29,8 +29,7 @@ const About = () => {
 			<AboutDescription />
 
 			<div
-				className="w-full max-w-[95rem] flex items-center justify-between fixed left-1/2 -translate-x-1/2 z-10 bottom-16 px-16"
-
+				className="w-[calc(100%-4.7rem)] flex items-center justify-between fixed left-[4.7rem] z-10 bottom-16 px-16"
 			>
 				{/* PREVIOUS STEP BUTTON */}
 				<Link href={'/app/onboarding?step=welcome'}>

--- a/components/onboarding/About.tsx
+++ b/components/onboarding/About.tsx
@@ -28,7 +28,10 @@ const About = () => {
 			{/* DESCRIPTION TEXT */}
 			<AboutDescription />
 
-			<div className="w-full flex items-center justify-between absolute left-1/2 -translate-x-1/2 bottom-16 px-16">
+			<div
+				className="w-full max-w-[95rem] flex items-center justify-between fixed left-1/2 -translate-x-1/2 z-10 bottom-16 px-16"
+
+			>
 				{/* PREVIOUS STEP BUTTON */}
 				<Link href={'/app/onboarding?step=welcome'}>
 					<Button

--- a/components/onboarding/About.tsx
+++ b/components/onboarding/About.tsx
@@ -8,7 +8,7 @@ const About = () => {
 	return (
 		<div className="w-full h-full flex flex-col justify-center items-center">
 			{/* HEADING TEXT */}
-			<div className="">
+			<div className="pt-48">
 				<TextAnimate
 					text="Here's"
 					type="calmInUp"

--- a/components/onboarding/BaseResume.tsx
+++ b/components/onboarding/BaseResume.tsx
@@ -7,7 +7,7 @@ const BaseResume = async () => {
 	const baseResume = await getBaseResumeFromDB(userId!)
 
 	return (
-		<div className="w-full h-full flex flex-col justify-start pl-16 pb-40 pt-16">
+		<div className="w-full h-full flex flex-col justify-start pl-16 mb-40 pt-16">
 			<ResumeView resume={baseResume} />
 		</div>
 	)

--- a/components/onboarding/BaseResume.tsx
+++ b/components/onboarding/BaseResume.tsx
@@ -7,7 +7,7 @@ const BaseResume = async () => {
 	const baseResume = await getBaseResumeFromDB(userId!)
 
 	return (
-		<div className="w-full h-full flex flex-col justify-start pl-16 pt-16">
+		<div className="w-full h-full flex flex-col justify-start pl-16 pb-40 pt-16">
 			<ResumeView resume={baseResume} />
 		</div>
 	)

--- a/components/onboarding/Education.tsx
+++ b/components/onboarding/Education.tsx
@@ -51,7 +51,7 @@ const Education = ({allEducations}: { allEducations: (typeof educations.$inferSe
 	}
 
 	return (
-		<div className="w-full h-full flex flex-col justify-start pl-16 pb-40 pt-16">
+		<div className="w-full h-full flex flex-col justify-start pl-16 mb-40 pt-16">
 			<ScrollArea>
 				{/* HEADING TEXT */}
 				<div>

--- a/components/onboarding/Education.tsx
+++ b/components/onboarding/Education.tsx
@@ -12,6 +12,7 @@ import {X} from 'lucide-react'
 import PopConfirm from '@/components/ui/pop-confirm'
 import {toast} from 'sonner'
 import {deleteEducationFromDB} from '@/lib/education.methods'
+import {ScrollArea} from '../ui/scroll-area'
 
 const Education = ({allEducations}: { allEducations: (typeof educations.$inferSelect)[] }) => {
 	const [currentEducations, setCurrentEducations] = useState<z.infer<typeof educationFormSchema>[]>(allEducations.map(education => ({
@@ -51,27 +52,29 @@ const Education = ({allEducations}: { allEducations: (typeof educations.$inferSe
 
 	return (
 		<div className="w-full h-full flex flex-col justify-start pl-16 pt-16">
-			{/* HEADING TEXT */}
-			<div>
-				<TextAnimate
-					text="Tell us more"
-					type="calmInUp"
-					className="text-5xl leading-snug"
-					{...({} as any)}
+			<ScrollArea>
+				{/* HEADING TEXT */}
+				<div>
+					<TextAnimate
+						text="Tell us more"
+						type="calmInUp"
+						className="text-5xl leading-snug"
+						{...({} as any)}
 					// Framer-motion types are broken as of 22/10/2024
-				/>
-				<TextAnimate
-					text="about your education"
-					type="calmInUp"
-					className="text-5xl leading-snug"
-					{...({} as any)}
+					/>
+					<TextAnimate
+						text="about your education"
+						type="calmInUp"
+						className="text-5xl leading-snug"
+						{...({} as any)}
 					// Framer-motion types are broken as of 22/10/2024
-				/>
-			</div>
+					/>
+				</div>
 
-			{/* FORM */}
-			<EducationForm educations={currentEducations} setEducations={setCurrentEducations} />
+				{/* FORM */}
+				<EducationForm educations={currentEducations} setEducations={setCurrentEducations} />
 
+			</ScrollArea>
 			{/* EDUCATIONS */}
 			<motion.div
 				initial={{opacity: 0, y: '-30%'}}

--- a/components/onboarding/Education.tsx
+++ b/components/onboarding/Education.tsx
@@ -51,7 +51,7 @@ const Education = ({allEducations}: { allEducations: (typeof educations.$inferSe
 	}
 
 	return (
-		<div className="w-full h-full flex flex-col justify-start pl-16 pt-16">
+		<div className="w-full h-full flex flex-col justify-start pl-16 pb-40 pt-16">
 			<ScrollArea>
 				{/* HEADING TEXT */}
 				<div>

--- a/components/onboarding/EducationForm.tsx
+++ b/components/onboarding/EducationForm.tsx
@@ -291,8 +291,9 @@ const EducationForm = ({
 					</motion.div>
 
 					<div
-						className="w-full flex items-center justify-between absolute left-1/2 -translate-x-1/2
-						bottom-16 px-16"
+						className="w-full max-w-[95rem] flex items-center justify-between fixed left-1/2 -translate-x-1/2 z-10 bottom-16 px-16"
+
+
 					>
 						{/* PREVIOUS STEP BUTTON */}
 						<Link href={'/app/onboarding?step=personal-details'}>
@@ -307,7 +308,7 @@ const EducationForm = ({
 						</Link>
 
 						{/* NEXT STEP BUTTONS */}
-						<div className="flex items-center gap-4">
+						<div className=" flex items-center gap-4">
 							<Button
 								className="transition rounded-full shadow-lg px-6 hover:shadow-xl"
 								variant="secondary"

--- a/components/onboarding/EducationForm.tsx
+++ b/components/onboarding/EducationForm.tsx
@@ -291,9 +291,7 @@ const EducationForm = ({
 					</motion.div>
 
 					<div
-						className="w-full max-w-[95rem] flex items-center justify-between fixed left-1/2 -translate-x-1/2 z-10 bottom-16 px-16"
-
-
+						className="w-[calc(100%-4.7rem)] flex items-center justify-between fixed left-[4.7rem] z-10 bottom-16 px-16"
 					>
 						{/* PREVIOUS STEP BUTTON */}
 						<Link href={'/app/onboarding?step=personal-details'}>

--- a/components/onboarding/Experience.tsx
+++ b/components/onboarding/Experience.tsx
@@ -50,7 +50,7 @@ const Experience = ({allExperiences}: { allExperiences: (typeof experiences.$inf
 	}
 
 	return (
-		<div className="w-full h-full flex flex-col justify-start pl-16 pt-16">
+		<div className="w-full h-full flex flex-col justify-start pl-16 pb-40 pt-16">
 			{/* HEADING TEXT */}
 			<div>
 				<TextAnimate

--- a/components/onboarding/Experience.tsx
+++ b/components/onboarding/Experience.tsx
@@ -50,7 +50,7 @@ const Experience = ({allExperiences}: { allExperiences: (typeof experiences.$inf
 	}
 
 	return (
-		<div className="w-full h-full flex flex-col justify-start pl-16 pb-40 pt-16">
+		<div className="w-full h-full flex flex-col justify-start pl-16 mb-40 pt-16">
 			{/* HEADING TEXT */}
 			<div>
 				<TextAnimate

--- a/components/onboarding/ExperienceForm.tsx
+++ b/components/onboarding/ExperienceForm.tsx
@@ -280,7 +280,8 @@ const ExperienceForm = ({className, experiences, setExperiences}: ExperienceForm
 					</motion.div>
 
 					<div
-						className="w-full max-w-[95rem] flex items-center justify-between fixed left-1/2 -translate-x-1/2 z-10 bottom-16 px-16"
+						className="w-[calc(100%-4.7rem)] flex items-center justify-between fixed left-[4.7rem] z-10 bottom-16 px-16"
+
 					>
 						{/* PREVIOUS STEP BUTTON */}
 						<Link href={'/app/onboarding?step=education'}>

--- a/components/onboarding/ExperienceForm.tsx
+++ b/components/onboarding/ExperienceForm.tsx
@@ -101,7 +101,8 @@ const ExperienceForm = ({className, experiences, setExperiences}: ExperienceForm
 	}
 
 	return (
-		<div className={cn('max-w-2xl flex flex-col', className)}>
+		<div className={cn('max-w-2xl flex flex-col', className)}
+		>
 			<motion.div
 				className="text-xl mt-8 max-w-xl"
 				{...({} as any)}
@@ -279,8 +280,7 @@ const ExperienceForm = ({className, experiences, setExperiences}: ExperienceForm
 					</motion.div>
 
 					<div
-						className="w-full flex items-center justify-between absolute left-1/2 -translate-x-1/2
-						bottom-16 px-16"
+						className="w-full max-w-[95rem] flex items-center justify-between fixed left-1/2 -translate-x-1/2 z-10 bottom-16 px-16"
 					>
 						{/* PREVIOUS STEP BUTTON */}
 						<Link href={'/app/onboarding?step=education'}>

--- a/components/onboarding/PersonalDetailsForm.tsx
+++ b/components/onboarding/PersonalDetailsForm.tsx
@@ -138,8 +138,8 @@ const PersonalDetailsForm = ({className, defaultValues}: { className?: string, d
 					</motion.div>
 
 					<div
-						className="w-full flex items-center justify-between absolute left-1/2 -translate-x-1/2
-						bottom-16 px-16"
+						className="w-full max-w-[95rem] flex items-center justify-between fixed left-1/2 -translate-x-1/2 z-10 bottom-16 px-16"
+
 					>
 						{/* PREVIOUS STEP BUTTON */}
 						<Link href={'/app/onboarding?step=about'}>

--- a/components/onboarding/PersonalDetailsForm.tsx
+++ b/components/onboarding/PersonalDetailsForm.tsx
@@ -138,8 +138,7 @@ const PersonalDetailsForm = ({className, defaultValues}: { className?: string, d
 					</motion.div>
 
 					<div
-						className="w-full max-w-[95rem] flex items-center justify-between fixed left-1/2 -translate-x-1/2 z-10 bottom-16 px-16"
-
+						className="w-[calc(100%-4.7rem)] flex items-center justify-between fixed left-[4.7rem] z-10 bottom-16 px-16"
 					>
 						{/* PREVIOUS STEP BUTTON */}
 						<Link href={'/app/onboarding?step=about'}>

--- a/components/onboarding/Welcome.tsx
+++ b/components/onboarding/Welcome.tsx
@@ -6,7 +6,7 @@ import {Link} from 'next-view-transitions'
 
 const Welcome = () => {
 	return (
-		<>
+		<div className="min-h-dvh">
 			{/* HEADING TEXT */}
 			<div className="absolute top-8 left-8">
 				<TextAnimate
@@ -46,7 +46,7 @@ const Welcome = () => {
 					<ChevronRight className="w-5 h-5 ml-1" />
 				</Button>
 			</Link>
-		</>
+		</div>
 	)
 }
 

--- a/components/providers/SmoothScrollProvider.tsx
+++ b/components/providers/SmoothScrollProvider.tsx
@@ -28,7 +28,7 @@ const SmoothScrollProvider = ({children, className}: { children: ReactNode, clas
 
 	return (
 		<div className={className} ref={wrapper}>
-			<main ref={content} className="h-full">
+			<main ref={content}>
 				{children}
 			</main>
 		</div>

--- a/components/providers/SmoothScrollProvider.tsx
+++ b/components/providers/SmoothScrollProvider.tsx
@@ -28,7 +28,7 @@ const SmoothScrollProvider = ({children, className}: { children: ReactNode, clas
 
 	return (
 		<div className={className} ref={wrapper}>
-			<main ref={content}>
+			<main ref={content} >
 				{children}
 			</main>
 		</div>


### PR DESCRIPTION
### Issue:
[LET-13/bug-onboarding-page-next-and-prev-button-overlapping-elements-in-low](https://linear.app/letraz/issue/LET-13/bug-onboarding-page-next-and-prev-button-overlapping-elements-in-low)

### Description:
This issue addresses the overlapping of the "Next" and "Previous" buttons with other elements on the onboarding page when viewed on smaller screen sizes. The buttons were incorrectly positioned, causing visual issues and interfering with the user experience.

### Implemented Changes:
- Wrapped containers in ShadCN scroll area to ensure proper scrolling behavior and prevent overlap.
- Made the button containers fixed to maintain their position regardless of the content above or below.
- Fixed responsiveness issues related to button placement and layout for a smoother user experience across different screen sizes.

### Closing Note:
This update resolves the overlapping button issue on the onboarding page by making necessary layout adjustments. Additionally, a new minimal rich text editor was introduced to replace the old one. However, the switch component is experiencing a style conflict, which needs to be addressed in a future update.