### PR TITLE
LET-70 | feat: Filter out internal users in Posthog depending on the host

### DIFF
--- a/components/providers/PosthogProvider.tsx
+++ b/components/providers/PosthogProvider.tsx
@@ -3,8 +3,9 @@
 import posthog from 'posthog-js'
 import {PostHogProvider} from 'posthog-js/react'
 import {ReactNode} from 'react'
+import {defaultUrl} from '@/config'
 
-if (typeof window !== 'undefined') {
+if (typeof window !== 'undefined' && defaultUrl.match(/^.((localhost|\d+.\d+.\d+.\d+)|vercel.app).$/)) {
 	posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
 		api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
 		person_profiles: 'always'


### PR DESCRIPTION
### Issue:
[LET-70: impr: Filter out internal users and their sessions for PostHog analytics](https://linear.app/letraz/issue/LET-70/impr-filter-out-internal-users-and-their-sessions-for-posthog)

### Description:
This PR improves PostHog analytics accuracy by filtering out events and sessions from internal users, ensuring data reflects real user behavior.

### Implemented Changes:
- **Internal User Identification:** Implemented identification of internal users using a specific host domain (configured via environment variables).
- **PostHog Event Filtering:** Added logic to prevent sending events from identified internal users to PostHog.
- **Testing:** Thoroughly tested the filtering mechanism with internal and external user accounts, verifying that only external user data appears in PostHog reports.  The filtering logic is clearly documented.

### Closing Note:
PostHog analytics now accurately reflect real user behavior by excluding data from internal users.  The filtering mechanism is robust and configurable via environment variables for easy maintenance and updates.