### PR TITLE
feat(resume): Add Projects section support to default resume theme

### DIFF
--- a/components/resume/controllers/ProjectController.tsx
+++ b/components/resume/controllers/ProjectController.tsx
@@ -1,0 +1,162 @@
+import React from 'react'
+import {ResumeSection} from '@/lib/resume/types'
+import {Project} from '@/lib/project/types'
+import {sanitizeHtml} from '@/lib/utils'
+
+// Types for the processed data
+export interface ProjectData {
+  name: string
+  category: {
+    hasCategory: boolean
+    value?: string
+  }
+  description: {
+    hasDescription: boolean
+    sanitizedHtml?: string
+  }
+  technologies: {
+    hasTechnologies: boolean
+    list: string[]
+  }
+  role: {
+    hasRole: boolean
+    value?: string
+  }
+  links: {
+    hasLinks: boolean
+    github?: string
+    live?: string
+  }
+  accomplishments: {
+    hasAccomplishments: boolean
+    list: string[]
+  }
+  dates: {
+    hasDates: boolean
+    formatted: string
+  }
+  spacing: {
+    marginTop: boolean
+  }
+}
+
+// Controller hook that processes raw Project data into display-ready data
+export const useProjectController = (
+	section: ResumeSection & { type: 'Project', data: Project },
+	isFirstInGroup: boolean
+): ProjectData => {
+	return React.useMemo(() => {
+		const {data: project} = section
+
+		// Process category
+		const category = {
+			hasCategory: Boolean(project.category),
+			value: project.category || undefined
+		}
+
+		// Process description
+		const description = {
+			hasDescription: Boolean(project.description),
+			sanitizedHtml: project.description
+				? sanitizeHtml(project.description)
+				: undefined
+		}
+
+		// Process technologies from skills_used
+		const technologies = {
+			hasTechnologies: project.skills_used && project.skills_used.length > 0,
+			list: project.skills_used?.map(skill => skill.name) || []
+		}
+
+		// Process role
+		const role = {
+			hasRole: Boolean(project.role),
+			value: project.role || undefined
+		}
+
+		// Process links
+		const links = {
+			hasLinks: Boolean(project.github_url || project.live_url),
+			github: project.github_url || undefined,
+			live: project.live_url || undefined
+		}
+
+		/*
+		 * Process accomplishments - extracting from description if needed
+		 * Since the Project type doesn't have a separate accomplishments field,
+		 * we'll leave this empty for now but structure is ready for future use
+		 */
+		const accomplishments = {
+			hasAccomplishments: false,
+			list: []
+		}
+
+		// Process dates - similar to Experience dates formatting
+		const formatDate = (month: number | null | undefined, year: number) => {
+			if (!month) {
+				return year.toString()
+			}
+
+			const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+				'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+			const monthIndex = month - 1
+
+			if (monthIndex < 0 || monthIndex >= monthNames.length) {
+				return year.toString()
+			}
+
+			return `${monthNames[monthIndex]} ${year}`
+		}
+
+		let dateRange = ''
+		if (project.started_from_year) {
+			const startDate = formatDate(project.started_from_month, project.started_from_year)
+			if (project.current) {
+				dateRange = `${startDate} – Present`
+			} else if (project.finished_at_year) {
+				const endDate = formatDate(project.finished_at_month, project.finished_at_year)
+				dateRange = `${startDate} – ${endDate}`
+			} else {
+				dateRange = startDate
+			}
+		}
+
+		const dates = {
+			hasDates: Boolean(dateRange),
+			formatted: dateRange
+		}
+
+		// Spacing only between sections within the same group
+		const spacing = {
+			marginTop: !isFirstInGroup
+		}
+
+		return {
+			name: project.name,
+			category,
+			description,
+			technologies,
+			role,
+			links,
+			accomplishments,
+			dates,
+			spacing
+		}
+	}, [section, isFirstInGroup])
+}
+
+// HOC wrapper for theme components
+export interface ProjectControllerProps {
+  section: ResumeSection & { type: 'Project', data: Project }
+  isFirstInGroup: boolean
+  children: (data: ProjectData) => React.ReactNode
+}
+
+export const ProjectController: React.FC<ProjectControllerProps> = ({
+	section,
+	isFirstInGroup,
+	children
+}) => {
+	const processedData = useProjectController(section, isFirstInGroup)
+	return <>{children(processedData)}</>
+}

--- a/components/resume/themes/DEFAULT_THEME/DefaultTheme.tsx
+++ b/components/resume/themes/DEFAULT_THEME/DefaultTheme.tsx
@@ -6,9 +6,11 @@ import PersonalInfoSection from '@/components/resume/themes/DEFAULT_THEME/sectio
 import EducationSection from '@/components/resume/themes/DEFAULT_THEME/sections/EducationSection'
 import ExperienceSection from '@/components/resume/themes/DEFAULT_THEME/sections/ExperienceSection'
 import SkillsSection from '@/components/resume/themes/DEFAULT_THEME/sections/SkillsSection'
+import ProjectsSection from '@/components/resume/themes/DEFAULT_THEME/sections/ProjectsSection'
 import EducationTitle from '@/components/resume/themes/DEFAULT_THEME/sections/EducationTitle'
 import ExperienceTitle from '@/components/resume/themes/DEFAULT_THEME/sections/ExperienceTitle'
 import SkillsTitle from '@/components/resume/themes/DEFAULT_THEME/sections/SkillsTitle'
+import ProjectsTitle from '@/components/resume/themes/DEFAULT_THEME/sections/ProjectsTitle'
 
 // Create the default theme using the theme factory
 const DefaultTheme = createTheme({
@@ -17,9 +19,11 @@ const DefaultTheme = createTheme({
 		EducationSection,
 		ExperienceSection,
 		SkillsSection,
+		ProjectsSection,
 		EducationTitle,
 		ExperienceTitle,
-		SkillsTitle
+		SkillsTitle,
+		ProjectsTitle
 	},
 	// Apply Charter font and custom container class
 	className: `${charter.className} default-theme-container`

--- a/components/resume/themes/DEFAULT_THEME/sections/ProjectsSection.tsx
+++ b/components/resume/themes/DEFAULT_THEME/sections/ProjectsSection.tsx
@@ -1,0 +1,100 @@
+import '../fontawesome'
+import {charter} from '@/components/resume/themes/DEFAULT_THEME/fonts'
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome'
+import {faGithub} from '@fortawesome/free-brands-svg-icons'
+import {ProjectData} from '@/components/resume/controllers/ProjectController'
+
+// Project Section UI Component
+const ProjectsSection = ({data}: { data: ProjectData }) => {
+	// Error handling for missing project name
+	if (!data.name) {
+		return null
+	}
+
+	return (
+		<article className={`${charter.className} project-item ${data.spacing.marginTop ? 'mt-2' : ''}`} aria-label={`Project: ${data.name}`}>
+			{/* PROJECT HEADER */}
+			<div className="project-header">
+				{/* PROJECT NAME AND CATEGORY */}
+				<h3 className="project-title">
+					{data.name}
+					{data.category.hasCategory && (
+						<span className="project-category"> – {data.category.value}</span>
+					)}
+				</h3>
+
+				{/* PROJECT DATE */}
+				{data.dates.hasDates && (
+					<time className="project-date" aria-label="Project duration">{data.dates.formatted}</time>
+				)}
+			</div>
+
+			{/* PROJECT ROLE AND LINKS */}
+			<div className="project-subtitle">
+				{data.role.hasRole && (
+					<span className="project-role">{data.role.value}</span>
+				)}
+				{data.links.hasLinks && (
+					<span className="project-links" role="group" aria-label="Project links">
+						{data.role.hasRole && ' | '}
+						{data.links.github && (
+							<>
+								<a
+									href={data.links.github}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="project-link"
+									aria-label={`View ${data.name} on GitHub`}
+								>
+									<FontAwesomeIcon icon={faGithub} aria-hidden="true" />
+									<span> GitHub</span>
+								</a>
+								{data.links.live && ' | '}
+							</>
+						)}
+						{data.links.live && (
+							<a
+								href={data.links.live}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="project-link"
+								aria-label={`View ${data.name} live demo`}
+							>
+								Live Demo
+							</a>
+						)}
+					</span>
+				)}
+			</div>
+
+			{/* PROJECT TECHNOLOGIES */}
+			{data.technologies.hasTechnologies && (
+				<div className="project-technologies">
+					<span className="tech-label">Skills used: </span>
+					<span className="tech-list">{data.technologies.list.join(', ')}</span>
+				</div>
+			)}
+
+			{/* PROJECT DESCRIPTION */}
+			{data.description.hasDescription && (
+				<div
+					className="project-details"
+					dangerouslySetInnerHTML={{__html: data.description.sanitizedHtml || ''}}
+				/>
+			)}
+
+			{/* PROJECT ACCOMPLISHMENTS */}
+			{data.accomplishments.hasAccomplishments && (
+				<ul className="project-accomplishments">
+					{data.accomplishments.list.map((accomplishment, index) => (
+						<li key={index} className="accomplishment-item">
+							{accomplishment}
+						</li>
+					))}
+				</ul>
+			)}
+		</article>
+	)
+}
+
+export default ProjectsSection

--- a/components/resume/themes/DEFAULT_THEME/sections/ProjectsTitle.tsx
+++ b/components/resume/themes/DEFAULT_THEME/sections/ProjectsTitle.tsx
@@ -1,0 +1,9 @@
+import {charter} from '@/components/resume/themes/DEFAULT_THEME/fonts'
+
+const ProjectsTitle = () => {
+	return (
+		<div className={`${charter.className} section-header`}>Projects</div>
+	)
+}
+
+export default ProjectsTitle

--- a/components/resume/themes/DEFAULT_THEME/styles.css
+++ b/components/resume/themes/DEFAULT_THEME/styles.css
@@ -266,3 +266,164 @@
   font-weight: 400;
   font-family: "Charter", "Times New Roman", Times, serif;
 }
+
+/* Projects section styling */
+.default-theme-container .project-item {
+  margin-bottom: 8px;
+}
+
+.default-theme-container .project-item:last-child {
+  margin-bottom: 0;
+}
+
+.default-theme-container .project-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 4px;
+  gap: 20px;
+}
+
+.default-theme-container .project-title {
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.27;
+  font-family: "Charter", "Times New Roman", Times, serif;
+  margin: 0;
+  display: inline;
+  flex: 1;
+  min-width: 0;
+}
+
+.default-theme-container .project-category {
+  font-style: italic;
+  font-weight: 400;
+  font-family: "Charter", "Times New Roman", Times, serif;
+}
+
+.default-theme-container .project-date {
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.27;
+  font-family: "Charter", "Times New Roman", Times, serif;
+  flex-shrink: 0;
+  text-align: right;
+}
+
+.default-theme-container .project-subtitle {
+  font-size: 13px;
+  line-height: 1.27;
+  margin-bottom: 2px;
+  font-family: "Charter", "Times New Roman", Times, serif;
+}
+
+.default-theme-container .project-role {
+  font-style: italic;
+  font-family: "Charter", "Times New Roman", Times, serif;
+}
+
+.default-theme-container .project-links {
+  font-family: "Charter", "Times New Roman", Times, serif;
+}
+
+.default-theme-container .project-link {
+  color: #000;
+  text-decoration: none;
+  transition: opacity 0.2s;
+  font-family: "Charter", "Times New Roman", Times, serif;
+}
+
+.default-theme-container .project-link:hover {
+  opacity: 0.7;
+}
+
+.default-theme-container .project-link svg {
+  font-size: 12px;
+  width: 12px;
+  height: 12px;
+  margin-right: 2px;
+}
+
+.default-theme-container .project-technologies {
+  font-size: 13px;
+  line-height: 1.27;
+  margin-bottom: 4px;
+  font-family: "Charter", "Times New Roman", Times, serif;
+}
+
+.default-theme-container .tech-label {
+  font-weight: 600;
+  font-family: "Charter", "Times New Roman", Times, serif;
+}
+
+.default-theme-container .tech-list {
+  font-weight: 400;
+  font-family: "Charter", "Times New Roman", Times, serif;
+}
+
+.default-theme-container .project-details {
+  font-size: 13px;
+  line-height: 1.27;
+  font-weight: 400;
+  margin-bottom: 6px;
+  font-family: "Charter", "Times New Roman", Times, serif;
+}
+
+.default-theme-container .project-details ul {
+  margin-left: 4px;
+  padding-left: 0;
+  list-style: none;
+}
+
+.default-theme-container .project-details li {
+  font-size: 13px;
+  margin-bottom: 2.5px;
+  line-height: 1.27;
+  font-weight: 400;
+  position: relative;
+  padding-left: 10px;
+  font-family: "Charter", "Times New Roman", Times, serif;
+}
+
+.default-theme-container .project-details li::before {
+  content: "•";
+  font-size: 16px;
+  font-weight: bold;
+  position: absolute;
+  left: -4px;
+  top: -1px;
+  color: black;
+  font-family: "Charter", "Times New Roman", Times, serif;
+}
+
+.default-theme-container .project-details p {
+  margin: 0;
+  font-family: "Charter", "Times New Roman", Times, serif;
+}
+
+.default-theme-container .project-accomplishments {
+  margin-left: 4px;
+  padding-left: 0;
+  list-style: none;
+}
+
+.default-theme-container .accomplishment-item {
+  font-size: 13px;
+  margin-bottom: 2.5px;
+  line-height: 1.27;
+  font-weight: 400;
+  position: relative;
+  padding-left: 10px;
+  font-family: "Charter", "Times New Roman", Times, serif;
+}
+
+.default-theme-container .accomplishment-item::before {
+  content: "•";
+  font-size: 16px;
+  font-weight: bold;
+  position: absolute;
+  left: -4px;
+  top: -1px;
+  color: black;
+  font-family: "Charter", "Times New Roman", Times, serif;
+}

--- a/components/resume/themes/ThemeFactory.tsx
+++ b/components/resume/themes/ThemeFactory.tsx
@@ -6,12 +6,14 @@ import {UserInfo} from '@/lib/user-info/types'
 import {Education} from '@/lib/education/types'
 import {Experience} from '@/lib/experience/types'
 import {ResumeSkill} from '@/lib/skill/types'
+import {Project} from '@/lib/project/types'
 import SmoothScrollProvider from '@/components/providers/SmoothScrollProvider'
 import ReorderableSections from '@/components/resume/ReorderableSections'
 import {PersonalInfoController, PersonalInfoData} from '@/components/resume/controllers/PersonalInfoController'
 import {EducationController, EducationData} from '@/components/resume/controllers/EducationController'
 import {ExperienceController, ExperienceData} from '@/components/resume/controllers/ExperienceController'
 import {SkillsController, SkillsData} from '@/components/resume/controllers/SkillsController'
+import {ProjectController, ProjectData} from '@/components/resume/controllers/ProjectController'
 import {cn} from '@/lib/utils'
 
 // Standard theme props interface
@@ -28,9 +30,11 @@ export interface ThemeComponents {
 	EducationSection: React.ComponentType<{data: EducationData}>
 	ExperienceSection: React.ComponentType<{data: ExperienceData}>
 	SkillsSection: React.ComponentType<{data: SkillsData}>
+	ProjectsSection: React.ComponentType<{data: ProjectData}>
 	EducationTitle: React.ComponentType
 	ExperienceTitle: React.ComponentType
 	SkillsTitle: React.ComponentType
+	ProjectsTitle: React.ComponentType
 }
 
 // Theme configuration interface
@@ -57,6 +61,8 @@ export const createTheme = (config: ThemeConfig) => {
 					return <config.components.ExperienceTitle />
 				} else if (section.type === 'Skill') {
 					return <config.components.SkillsTitle />
+				} else if (section.type === 'Project') {
+					return <config.components.ProjectsTitle />
 				}
 				return null
 			})()
@@ -89,6 +95,15 @@ export const createTheme = (config: ThemeConfig) => {
 						>
 							{(data) => <config.components.SkillsSection data={data} />}
 						</SkillsController>
+					)
+				} else if (section.type === 'Project') {
+					return (
+						<ProjectController
+							section={section as ResumeSection & { type: 'Project', data: Project }}
+							isFirstInGroup={isFirstInGroup}
+						>
+							{(data) => <config.components.ProjectsSection data={data} />}
+						</ProjectController>
 					)
 				}
 				return null

--- a/lib/resume/types.ts
+++ b/lib/resume/types.ts
@@ -2,6 +2,7 @@ import {EducationSchema} from '@/lib/education/types'
 import {ExperienceSchema} from '@/lib/experience/types'
 import {UserInfoSchema} from '@/lib/user-info/types'
 import {ResumeSkillSchema} from '@/lib/skill/types'
+import {ProjectSchema} from '@/lib/project/types'
 import {z} from 'zod'
 import {JobSchema} from '@/lib/job/types'
 
@@ -14,8 +15,8 @@ export const ResumeSectionSchema = z.object({
 	id: z.string().describe('The unique identifier for the resume section.'),
 	resume: z.string().describe('The identifier of the resume this section belongs to.'),
 	index: z.number().describe('The position of this section within the resume.'),
-	type: z.enum(['Education', 'Experience', 'Skill']).describe('The type of the resume section: Education, Experience, or Skill.'),
-	data: z.union([EducationSchema, ExperienceSchema, z.array(ResumeSkillSchema)]).describe('The data associated with this section: education details, experience details, or array of skills.')
+	type: z.enum(['Education', 'Experience', 'Skill', 'Project']).describe('The type of the resume section: Education, Experience, Skill, or Project.'),
+	data: z.union([EducationSchema, ExperienceSchema, z.array(ResumeSkillSchema), ProjectSchema]).describe('The data associated with this section: education details, experience details, array of skills, or project details.')
 })
 
 export const ResumeSchema = z.object({


### PR DESCRIPTION
### Issue:
[core: Project section for the default theme](https://linear.app/letraz/issue/LET-17/core-project-section-for-the-default-theme)

### Description:
This PR addresses the creation of a dedicated `Projects` section component for the default resume theme. The component will showcase the user's projects in a structured and visually appealing manner.

### Changes Made:
- Added a new file `ProjectsSection.tsx` for the `Projects` section component.
- Modified `DefaultTheme.tsx` to include `ProjectsSection` in the default theme.
- Created `ProjectsSection.tsx` to render project information with consistent styling.
- Added `ProjectsTitle.tsx` for the title of the `Projects` section.
- Updated styles in `styles.css` for the `Projects` section layout.

### Closing Note:
This PR introduces a crucial feature that enhances the default resume theme by allowing users to effectively display their project work.