### PR TITLE
LET-118 | core: Refactor skill types to accommodate for the changed structure of backend response

### DIFF
--- a/components/resume/controllers/SkillsController.tsx
+++ b/components/resume/controllers/SkillsController.tsx
@@ -23,11 +23,11 @@ export interface SkillsData {
 
 // Controller hook that processes raw ResumeSkill data into display-ready data
 export const useSkillsController = (
-	section: ResumeSection & { type: 'Skill', data: ResumeSkill[] },
+	section: ResumeSection & { type: 'Skill', data: { skills: ResumeSkill[] } },
 	isFirstInGroup: boolean
 ): SkillsData => {
 	return React.useMemo(() => {
-		const {data: resumeSkills} = section
+		const {data: {skills: resumeSkills}} = section
 
 		// Process individual skills
 		const skills: SkillData[] = resumeSkills.map(resumeSkill => {
@@ -74,7 +74,7 @@ export const useSkillsController = (
 
 // HOC wrapper for theme components
 export interface SkillsControllerProps {
-  section: ResumeSection & { type: 'Skill', data: ResumeSkill[] }
+  section: ResumeSection & { type: 'Skill', data: { skills: ResumeSkill[] } }
   isFirstInGroup: boolean
   children: (data: SkillsData) => React.ReactNode
 }

--- a/components/resume/themes/ThemeFactory.tsx
+++ b/components/resume/themes/ThemeFactory.tsx
@@ -5,7 +5,7 @@ import {ResumeSection} from '@/lib/resume/types'
 import {UserInfo} from '@/lib/user-info/types'
 import {Education} from '@/lib/education/types'
 import {Experience} from '@/lib/experience/types'
-import {ResumeSkill} from '@/lib/skill/types'
+import {ResumeSkillSection} from '@/lib/skill/types'
 import SmoothScrollProvider from '@/components/providers/SmoothScrollProvider'
 import ReorderableSections from '@/components/resume/ReorderableSections'
 import {PersonalInfoController, PersonalInfoData} from '@/components/resume/controllers/PersonalInfoController'
@@ -84,7 +84,7 @@ export const createTheme = (config: ThemeConfig) => {
 				} else if (section.type === 'Skill') {
 					return (
 						<SkillsController
-							section={section as ResumeSection & { type: 'Skill', data: ResumeSkill[] }}
+							section={section as ResumeSection & { type: 'Skill', data: ResumeSkillSection }}
 							isFirstInGroup={isFirstInGroup}
 						>
 							{(data) => <config.components.SkillsSection data={data} />}

--- a/lib/resume/types.ts
+++ b/lib/resume/types.ts
@@ -1,9 +1,11 @@
 import {EducationSchema} from '@/lib/education/types'
 import {ExperienceSchema} from '@/lib/experience/types'
 import {UserInfoSchema} from '@/lib/user-info/types'
-import {ResumeSkillSchema} from '@/lib/skill/types'
+import {ResumeSkillSectionSchema} from '@/lib/skill/types'
 import {z} from 'zod'
 import {JobSchema} from '@/lib/job/types'
+import {CertificationSchema} from '@/lib/certification/types'
+import {ProjectSchema} from '@/lib/project/types'
 
 /*
  * Base schema for Resume and its sections
@@ -14,8 +16,8 @@ export const ResumeSectionSchema = z.object({
 	id: z.string().describe('The unique identifier for the resume section.'),
 	resume: z.string().describe('The identifier of the resume this section belongs to.'),
 	index: z.number().describe('The position of this section within the resume.'),
-	type: z.enum(['Education', 'Experience', 'Skill']).describe('The type of the resume section: Education, Experience, or Skill.'),
-	data: z.union([EducationSchema, ExperienceSchema, z.array(ResumeSkillSchema)]).describe('The data associated with this section: education details, experience details, or array of skills.')
+	type: z.enum(['Education', 'Experience', 'Skill', 'Project', 'Certification']).describe('The type of the resume section: Education, Experience, or Skill.'),
+	data: z.union([EducationSchema, ExperienceSchema, ResumeSkillSectionSchema, CertificationSchema, ProjectSchema]).describe('The data associated with this section: education details, experience details, or array of skills.')
 })
 
 export const ResumeSchema = z.object({

--- a/lib/skill/types.ts
+++ b/lib/skill/types.ts
@@ -68,6 +68,10 @@ export const ResumeSkillSchema = z.object({
 	level: SkillLevelEnum.nullable().describe('The proficiency level of the skill.')
 })
 
+export const ResumeSkillSectionSchema = z.object({
+	skills: z.array(ResumeSkillSchema)
+})
+
 /*
  * Schema for adding a new skill to a resume
  */
@@ -85,6 +89,7 @@ export const SkillMutationSchema = z.object({
 export type SkillAlias = z.infer<typeof SkillAliasSchema>
 export type GlobalSkill = z.infer<typeof GlobalSkillSchema>
 export type ResumeSkill = z.infer<typeof ResumeSkillSchema>
+export type ResumeSkillSection = z.infer<typeof ResumeSkillSectionSchema>
 export type SkillMutation = z.infer<typeof SkillMutationSchema>
 export type SkillLevel = z.infer<typeof SkillLevelEnum>
 


### PR DESCRIPTION
### Issue:
[LET-118 | core: Refactor skill types to accommodate for the changed structure of backend response](https://linear.app/letraz/issue/LET-118/core-refactor-skill-types-to-accommodate-for-the-changed-structure-of)

### Description:
This pull request addresses the refactoring of the frontend (React/TypeScript) to align with the modified structure of the `skills` section in the backend response for the resume object.

### Changes Made:
- Updated TypeScript interfaces in `letraz-client` to reflect the new structure of the `skills` section.
- Refactored the `SkillsEditor` component to handle skill data within the `{ skills: Skill[] }` object.
- Adjusted the `SkillsSection` component to display skills from `props.data.skills` and maintain category grouping and proficiency levels.
- Reviewed and updated data fetching and processing logic to accommodate the new `skills` data structure.
- Conducted thorough testing for adding, editing, and removing skills, as well as ensuring correct display and persistence of skills data.

### Closing Note:
This PR is crucial to ensure seamless integration of the updated backend response structure into the frontend, maintaining consistency and accuracy in displaying skills within the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "Project" and "Certification" sections in resumes.

* **Refactor**
  * Updated the structure of the skills section to group skills within an object for improved consistency across resume sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->