### PR TITLE
LET-20 | core: Certification section for the default theme

### DIFF
--- a/components/resume/controllers/CertificationController.tsx
+++ b/components/resume/controllers/CertificationController.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import {ResumeSection} from '@/lib/resume/types'
+import {Certification} from '@/lib/certification/types'
+
+// Types for the processed data
+export interface CertificationData {
+  name: string
+  issuingOrganization: {
+    hasOrganization: boolean
+    value?: string
+  }
+  issueDate: {
+    hasDate: boolean
+    formatted?: string
+  }
+  credentialUrl: {
+    hasUrl: boolean
+    value?: string
+  }
+  spacing: {
+    marginTop: boolean
+  }
+}
+
+// Controller hook that processes raw Certification data into display-ready data
+export const useCertificationController = (
+	section: ResumeSection & { type: 'Certification', data: Certification },
+	isFirstInGroup: boolean
+): CertificationData => {
+	return React.useMemo(() => {
+		const {data: certification} = section
+
+		// Process issuing organization
+		const issuingOrganization = {
+			hasOrganization: Boolean(certification.issuing_organization),
+			value: certification.issuing_organization || undefined
+		}
+
+		// Process issue date
+		const formatDate = (dateString: string | null | undefined) => {
+			if (!dateString) return undefined
+
+			try {
+				const date = new Date(dateString)
+				const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+					'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+				const month = monthNames[date.getMonth()]
+				const year = date.getFullYear()
+				return `${month} ${year}`
+			} catch {
+				return dateString
+			}
+		}
+
+		const issueDate = {
+			hasDate: Boolean(certification.issue_date),
+			formatted: formatDate(certification.issue_date)
+		}
+
+		// Process credential URL
+		const credentialUrl = {
+			hasUrl: Boolean(certification.credential_url),
+			value: certification.credential_url || undefined
+		}
+
+		// Spacing only between sections within the same group
+		const spacing = {
+			marginTop: !isFirstInGroup
+		}
+
+		return {
+			name: certification.name,
+			issuingOrganization,
+			issueDate,
+			credentialUrl,
+			spacing
+		}
+	}, [section, isFirstInGroup])
+}
+
+// HOC wrapper for theme components
+export interface CertificationControllerProps {
+  section: ResumeSection & { type: 'Certification', data: Certification }
+  isFirstInGroup: boolean
+  children: (data: CertificationData) => React.ReactNode
+}
+
+export const CertificationController: React.FC<CertificationControllerProps> = ({
+	section,
+	isFirstInGroup,
+	children
+}) => {
+	const processedData = useCertificationController(section, isFirstInGroup)
+	return <>{children(processedData)}</>
+}

--- a/components/resume/controllers/CertificationController.tsx
+++ b/components/resume/controllers/CertificationController.tsx
@@ -36,15 +36,16 @@ export const useCertificationController = (
 			value: certification.issuing_organization || undefined
 		}
 
+		const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+			'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
 		// Process issue date
 		const formatDate = (dateString: string | null | undefined) => {
 			if (!dateString) return undefined
 
 			try {
 				const date = new Date(dateString)
-				const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-					'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-				const month = monthNames[date.getMonth()]
+				const month = MONTH_NAMES[date.getMonth()]
 				const year = date.getFullYear()
 				return `${month} ${year}`
 			} catch {

--- a/components/resume/themes/DEFAULT_THEME/DefaultTheme.tsx
+++ b/components/resume/themes/DEFAULT_THEME/DefaultTheme.tsx
@@ -7,10 +7,12 @@ import EducationSection from '@/components/resume/themes/DEFAULT_THEME/sections/
 import ExperienceSection from '@/components/resume/themes/DEFAULT_THEME/sections/ExperienceSection'
 import SkillsSection from '@/components/resume/themes/DEFAULT_THEME/sections/SkillsSection'
 import ProjectsSection from '@/components/resume/themes/DEFAULT_THEME/sections/ProjectsSection'
+import CertificationSection from '@/components/resume/themes/DEFAULT_THEME/sections/CertificationSection'
 import EducationTitle from '@/components/resume/themes/DEFAULT_THEME/sections/EducationTitle'
 import ExperienceTitle from '@/components/resume/themes/DEFAULT_THEME/sections/ExperienceTitle'
 import SkillsTitle from '@/components/resume/themes/DEFAULT_THEME/sections/SkillsTitle'
 import ProjectsTitle from '@/components/resume/themes/DEFAULT_THEME/sections/ProjectsTitle'
+import CertificationTitle from '@/components/resume/themes/DEFAULT_THEME/sections/CertificationTitle'
 
 // Create the default theme using the theme factory
 const DefaultTheme = createTheme({
@@ -20,10 +22,12 @@ const DefaultTheme = createTheme({
 		ExperienceSection,
 		SkillsSection,
 		ProjectsSection,
+		CertificationSection,
 		EducationTitle,
 		ExperienceTitle,
 		SkillsTitle,
-		ProjectsTitle
+		ProjectsTitle,
+		CertificationTitle
 	},
 	// Apply Charter font and custom container class
 	className: `${charter.className} default-theme-container`

--- a/components/resume/themes/DEFAULT_THEME/sections/CertificationSection.tsx
+++ b/components/resume/themes/DEFAULT_THEME/sections/CertificationSection.tsx
@@ -1,0 +1,52 @@
+import '../fontawesome'
+import {charter} from '@/components/resume/themes/DEFAULT_THEME/fonts'
+import {CertificationData} from '@/components/resume/controllers/CertificationController'
+
+
+// Certification Section UI Component
+const CertificationSection = ({data}: { data: CertificationData }) => {
+	// Error handling for missing certification name
+	if (!data.name) {
+		return null
+	}
+
+	return (
+		<article className={`${charter.className} certification-item ${data.spacing.marginTop ? 'mt-2' : ''}`} aria-label={`Certification: ${data.name}`}>
+			{/* CERTIFICATION HEADER */}
+			<div className="certification-header">
+				{/* CERTIFICATION NAME */}
+				<h3 className="certification-title">{data.name}</h3>
+
+				{/* CERTIFICATION DATE */}
+				{data.issueDate.hasDate && data.issueDate.formatted && (
+					<time className="certification-date" aria-label="Issue date">{data.issueDate.formatted}</time>
+				)}
+			</div>
+
+			{/* ISSUING ORGANIZATION AND CREDENTIAL LINK */}
+			{(data.issuingOrganization.hasOrganization || data.credentialUrl.hasUrl) && (
+				<div className="certification-subtitle">
+					{data.issuingOrganization.hasOrganization && data.issuingOrganization.value && (
+						<span className="certification-organization">{data.issuingOrganization.value}</span>
+					)}
+					{data.credentialUrl.hasUrl && data.credentialUrl.value && (
+						<span className="certification-links" role="group" aria-label="Certification links">
+							{data.issuingOrganization.hasOrganization && <span className="certification-separator" aria-hidden="true">|</span>}
+							<a
+								href={data.credentialUrl.value}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="certification-link"
+								aria-label={`View ${data.name} credential`}
+							>
+								View Certificate
+							</a>
+						</span>
+					)}
+				</div>
+			)}
+		</article>
+	)
+}
+
+export default CertificationSection

--- a/components/resume/themes/DEFAULT_THEME/sections/CertificationTitle.tsx
+++ b/components/resume/themes/DEFAULT_THEME/sections/CertificationTitle.tsx
@@ -1,0 +1,9 @@
+import {charter} from '@/components/resume/themes/DEFAULT_THEME/fonts'
+
+const CertificationTitle = () => {
+	return (
+		<div className={`${charter.className} section-header`}>Certifications</div>
+	)
+}
+
+export default CertificationTitle

--- a/components/resume/themes/DEFAULT_THEME/styles.css
+++ b/components/resume/themes/DEFAULT_THEME/styles.css
@@ -407,3 +407,72 @@
   margin: 0;
   font-family: "Charter", "Times New Roman", Times, serif;
 }
+
+/* Certifications section styling */
+.default-theme-container .certification-item {
+  margin-bottom: 8px;
+}
+
+.default-theme-container .certification-item:last-child {
+  margin-bottom: 0;
+}
+
+.default-theme-container .certification-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 4px;
+  gap: 20px;
+}
+
+.default-theme-container .certification-title {
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.27;
+  font-family: "Charter", "Times New Roman", Times, serif;
+  margin: 0;
+  flex: 1;
+  min-width: 0;
+}
+
+.default-theme-container .certification-date {
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.27;
+  font-family: "Charter", "Times New Roman", Times, serif;
+  flex-shrink: 0;
+  text-align: right;
+}
+
+.default-theme-container .certification-subtitle {
+  font-size: 13px;
+  line-height: 1.27;
+  margin-bottom: 2px;
+  font-family: "Charter", "Times New Roman", Times, serif;
+}
+
+.default-theme-container .certification-organization {
+  font-family: "Charter", "Times New Roman", Times, serif;
+}
+
+.default-theme-container .certification-links {
+  font-family: "Charter", "Times New Roman", Times, serif;
+}
+
+.default-theme-container .certification-link {
+  color: #000;
+  text-decoration: none;
+  transition: opacity 0.2s;
+  font-family: "Charter", "Times New Roman", Times, serif;
+}
+
+.default-theme-container .certification-link:hover {
+  opacity: 0.7;
+}
+
+.default-theme-container .certification-separator {
+  margin: 0 1px;
+  font-size: 12px;
+  color: #444;
+  font-family: "Charter", "Times New Roman", Times, serif;
+}

--- a/components/resume/themes/ThemeFactory.tsx
+++ b/components/resume/themes/ThemeFactory.tsx
@@ -7,6 +7,7 @@ import {Education} from '@/lib/education/types'
 import {Experience} from '@/lib/experience/types'
 import {Project} from '@/lib/project/types'
 import {ResumeSkillSection} from '@/lib/skill/types'
+import {Certification} from '@/lib/certification/types'
 import SmoothScrollProvider from '@/components/providers/SmoothScrollProvider'
 import ReorderableSections from '@/components/resume/ReorderableSections'
 import {PersonalInfoController, PersonalInfoData} from '@/components/resume/controllers/PersonalInfoController'
@@ -14,6 +15,7 @@ import {EducationController, EducationData} from '@/components/resume/controller
 import {ExperienceController, ExperienceData} from '@/components/resume/controllers/ExperienceController'
 import {SkillsController, SkillsData} from '@/components/resume/controllers/SkillsController'
 import {ProjectController, ProjectData} from '@/components/resume/controllers/ProjectController'
+import {CertificationController, CertificationData} from '@/components/resume/controllers/CertificationController'
 import {cn} from '@/lib/utils'
 
 // Standard theme props interface
@@ -31,10 +33,12 @@ export interface ThemeComponents {
 	ExperienceSection: React.ComponentType<{data: ExperienceData}>
 	SkillsSection: React.ComponentType<{data: SkillsData}>
 	ProjectsSection: React.ComponentType<{data: ProjectData}>
+	CertificationSection: React.ComponentType<{data: CertificationData}>
 	EducationTitle: React.ComponentType
 	ExperienceTitle: React.ComponentType
 	SkillsTitle: React.ComponentType
 	ProjectsTitle: React.ComponentType
+	CertificationTitle: React.ComponentType
 }
 
 // Theme configuration interface
@@ -63,6 +67,8 @@ export const createTheme = (config: ThemeConfig) => {
 					return <config.components.SkillsTitle />
 				} else if (section.type === 'Project') {
 					return <config.components.ProjectsTitle />
+				} else if (section.type === 'Certification') {
+					return <config.components.CertificationTitle />
 				}
 				return null
 			})()
@@ -104,6 +110,15 @@ export const createTheme = (config: ThemeConfig) => {
 						>
 							{(data) => <config.components.ProjectsSection data={data} />}
 						</ProjectController>
+					)
+				} else if (section.type === 'Certification') {
+					return (
+						<CertificationController
+							section={section as ResumeSection & { type: 'Certification', data: Certification }}
+							isFirstInGroup={isFirstInGroup}
+						>
+							{(data) => <config.components.CertificationSection data={data} />}
+						</CertificationController>
 					)
 				}
 				return null


### PR DESCRIPTION
### Issue:
[core: Certification section for the default theme](https://linear.app/letraz/issue/LET-20/core-certification-section-for-the-default-theme)

### Description:
This PR addresses the creation of the `Certification` section component for the default resume theme. The component will render a user's professional certifications in a visually appealing format based on the provided data model.

### Changes Made:
- Added a new file `CertificationSection.tsx` for the Certification section component.
- Integrated the Certification section component into the Default Theme layout.
- Implemented the UI structure for rendering certification information.
- Created the CertificationTitle component for the section header.
- Updated styles in `styles.css` for the Certification section.

### Closing Note:
This PR is crucial as it enhances the default resume theme by adding a Certification section that accurately displays professional certifications in a visually appealing manner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Certifications" section in the resume, including a dedicated title and section layout.
  * Certifications now display the name, issuing organization, issue date, and credential link (if available) in the default resume theme.
  * Added support for rendering and processing certification data with improved formatting and spacing logic.

* **Style**
  * Added new styles for the certifications section to ensure consistent layout and visual presentation within the resume.

* **Bug Fixes**
  * None.

* **Documentation**
  * None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->