### PR TITLE
LET-106 | comp: Display the resume previews with additional details in the dashboard

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,6 +1,7 @@
 import NewResumeInput from '@/components/NewResumeInput'
 import OnboardingWelcome from '@/components/onboarding/OnboardingWelcome'
 import {Suspense} from 'react'
+import DashboardResumeGrid from '@/components/dashboard/DashboardResumeGrid'
 
 const AppHome = () => {
 	return (
@@ -14,20 +15,7 @@ const AppHome = () => {
 
 			<div className="mt-16 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-8">
 				<NewResumeInput className="rounded-lg" />
-				<div className="h-96 w-full bg-red-200 rounded-lg" />
-				<div className="h-96 w-full bg-amber-200 rounded-lg" />
-				<div className="h-96 w-full bg-rose-200 rounded-lg" />
-				<div className="h-96 w-full bg-teal-200 rounded-lg" />
-				<div className="h-96 w-full bg-purple-200 rounded-lg" />
-				<div className="h-96 w-full bg-violet-200 rounded-lg" />
-				<div className="h-96 w-full bg-yellow-200 rounded-lg" />
-				<div className="h-96 w-full bg-flame-200 rounded-lg" />
-				<div className="h-96 w-full bg-lime-200 rounded-lg" />
-				<div className="h-96 w-full bg-sky-200 rounded-lg" />
-				<div className="h-96 w-full bg-emerald-200 rounded-lg" />
-				<div className="h-96 w-full bg-cyan-200 rounded-lg" />
-				<div className="h-96 w-full bg-green-200 rounded-lg" />
-				<div className="h-96 w-full bg-pink-200 rounded-lg" />
+				<DashboardResumeGrid />
 			</div>
 		</div>
 	)

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,18 @@
+/* Animated flowing gradient ONLY on border */
+.processing-border {
+  border: 2px solid transparent;
+  background:
+    linear-gradient(#ffffff, #ffffff) padding-box,
+    linear-gradient(90deg, #f97316, #f43f5e, #f59e0b, #facc15, #f97316) border-box;
+  background-size: 100% 100%, 200% 100%;
+  background-position: 0 0, 0 0;
+  background-repeat: no-repeat, repeat;
+  animation: border-flow 2s linear infinite;
+}
+
+@keyframes border-flow {
+  to { background-position: 0 0, 200% 0; }
+}
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/components/dashboard/DashboardResumeGrid.tsx
+++ b/components/dashboard/DashboardResumeGrid.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import {useResumes} from '@/lib/resume/queries'
+import {ResumeListItem} from '@/lib/resume/types'
+import ResumeCard from '@/components/dashboard/ResumeCard'
+
+const DashboardResumeGrid = () => {
+	const {data: resumes, isLoading} = useResumes()
+
+	return (
+		<>
+			{isLoading && Array.from({length: 8}).map((_, i) => (
+				<div key={`skeleton-${i}`} className="h-96 w-full rounded-lg border animate-pulse bg-neutral-100" />
+			))}
+			{!isLoading && resumes && (() => {
+				const baseResume = resumes.find(r => r.base)
+				const otherResumes = resumes.filter(r => !r.base)
+				const ordered = [baseResume, ...otherResumes].filter(Boolean) as ResumeListItem[]
+
+				const visible = ordered.filter(r => {
+					if (r.base) return true
+					const jobStatus = r.job?.status || null
+					if (jobStatus !== 'Success') return false
+					const resumeStatus = r.status || null
+					return !(resumeStatus !== 'Processing' && resumeStatus !== 'Success')
+				})
+
+				return visible.map((resume) => (
+					<ResumeCard key={resume.id} resume={resume} />
+				))
+			})()}
+		</>
+	)
+}
+
+export default DashboardResumeGrid
+
+

--- a/components/dashboard/ResumeCard.tsx
+++ b/components/dashboard/ResumeCard.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import Link from 'next/link'
+import {cn} from '@/lib/utils'
+import {ResumeListItem} from '@/lib/resume/types'
+import LoadingDots from '@/components/ui/loading-dots'
+import {Button} from '@/components/ui/button'
+import {Download} from 'lucide-react'
+
+type ResumeCardProps = {
+  resume: ResumeListItem
+  className?: string
+}
+
+const ResumeCard = ({resume, className}: ResumeCardProps) => {
+	const isProcessing = !resume.base && resume.status === 'Processing'
+
+	return (
+		<Link href={`/app/craft?jobId=${encodeURIComponent(resume.id)}`} className="group">
+			<div className={cn(isProcessing && 'processing-border rounded-lg')}>
+				<div className={cn(
+					'h-96 w-full rounded-lg transition hover:shadow-2xl focus-within:shadow-2xl overflow-hidden border bg-white flex flex-col',
+					resume.base && 'border-2 border-flame-400',
+					isProcessing && 'border-2 border-transparent',
+					className
+				)}>
+					<div className="flex-1 bg-white flex items-center justify-center overflow-hidden">
+						{isProcessing && (
+							<div className={cn('flex flex-col items-center justify-center')}>
+								<LoadingDots className="space-x-1" dotClassName="w-2 h-2 bg-flame-500" />
+								<p className="mt-2 font-jakarta font-semibold">One moment</p>
+								<p className="text-xs leading-normal opacity-80">We're crafting this one for you</p>
+							</div>
+						)}
+
+						{!isProcessing && (resume.thumbnail ? (
+						// eslint-disable-next-line @next/next/no-img-element
+							<img
+								src={resume.thumbnail}
+								alt={`${resume.job.title} at ${resume.job.company_name}`}
+								className="h-full w-full object-cover object-top"
+								onError={(e) => {(e.currentTarget as HTMLImageElement).style.display = 'none'}}
+							/>
+						) : (
+							<div className="text-sm text-neutral-500">No preview</div>
+						))}
+					</div>
+					<div className={cn('p-3 border-t bg-white', resume.base && 'bg-flame-500 text-white')}>
+						{!resume.base && (
+							<div className="flex items-center gap-2 justify-between">
+								<div className="text-sm flex flex-col min-w-0">
+									<p className="truncate flex-1 font-medium text-base">{resume.job.title}</p>
+									<p className="text-xs text-neutral-500 truncate">{resume.job.company_name}{resume.job.location && `, ${resume.job.location}`}</p>
+								</div>
+
+								{!isProcessing && (
+									<Button className="h-full opacity-0 group-hover:opacity-100" variant="outline">
+										<Download />
+									</Button>
+								)}
+							</div>
+						)}
+
+						{resume.base && (
+							<div className="flex items-center gap-2 justify-between">
+								<div className="text-sm flex flex-col min-w-0">
+									<p className="truncate flex-1 font-semibold text-base">Base resume</p>
+									<p className="text-xs text-white/70 truncate">Master resume for tailoring</p>
+								</div>
+
+								<Button className="h-full opacity-0 group-hover:opacity-100" variant="outline">
+									<Download />
+								</Button>
+							</div>
+						)}
+					</div>
+				</div>
+			</div>
+		</Link>
+	)
+}
+
+export default ResumeCard

--- a/components/ui/loading-dots.tsx
+++ b/components/ui/loading-dots.tsx
@@ -1,0 +1,18 @@
+import {cn} from '@/lib/utils'
+
+type LoadingDotsProps = {
+    className?: string
+    dotClassName?: string
+}
+
+const LoadingDots = ({className, dotClassName}: LoadingDotsProps) => {
+	return (
+		<div className={cn('flex items-center justify-center space-x-2', className)}>
+			<div className={cn('bg-primary h-5 w-5 animate-bounce rounded-full [animation-delay:-0.3s]', dotClassName)}></div>
+			<div className={cn('bg-primary h-5 w-5 animate-bounce rounded-full [animation-delay:-0.13s]', dotClassName)}></div>
+			<div className={cn('bg-primary h-5 w-5 animate-bounce rounded-full', dotClassName)}></div>
+		</div>
+	)
+}
+
+export default LoadingDots

--- a/lib/job/types.ts
+++ b/lib/job/types.ts
@@ -9,10 +9,10 @@ export const JobSchema = z.object({
 	title: z.string().describe('The title of the job position.'),
 	company_name: z.string().describe('The name of the company offering the job.'),
 	location: z.string().describe('The location where the job is based.'),
-	requirements: z.string().nullable().describe('The requirements for the job position. Nullable if not specified.'),
+    requirements: z.string().nullable().optional().describe('The requirements for the job position. Nullable if not specified.'),
 	description: z.string().describe('The description of the job position.'),
-	responsibilities: z.string().nullable().describe('The responsibilities associated with the job position. Nullable if not specified.'),
-	benefits: z.string().nullable().describe('The benefits provided by the company for the job position. Nullable if not specified.'),
+    responsibilities: z.string().nullable().optional().describe('The responsibilities associated with the job position. Nullable if not specified.'),
+    benefits: z.string().nullable().optional().describe('The benefits provided by the company for the job position. Nullable if not specified.'),
 	status: z.string().describe('Indicates if the job is currently being processed.').nullable().optional()
 })
 

--- a/lib/job/types.ts
+++ b/lib/job/types.ts
@@ -9,10 +9,10 @@ export const JobSchema = z.object({
 	title: z.string().describe('The title of the job position.'),
 	company_name: z.string().describe('The name of the company offering the job.'),
 	location: z.string().describe('The location where the job is based.'),
-    requirements: z.string().nullable().optional().describe('The requirements for the job position. Nullable if not specified.'),
+	requirements: z.string().nullable().optional().describe('The requirements for the job position. Nullable if not specified.'),
 	description: z.string().describe('The description of the job position.'),
-    responsibilities: z.string().nullable().optional().describe('The responsibilities associated with the job position. Nullable if not specified.'),
-    benefits: z.string().nullable().optional().describe('The benefits provided by the company for the job position. Nullable if not specified.'),
+	responsibilities: z.string().nullable().optional().describe('The responsibilities associated with the job position. Nullable if not specified.'),
+	benefits: z.string().nullable().optional().describe('The benefits provided by the company for the job position. Nullable if not specified.'),
 	status: z.string().describe('Indicates if the job is currently being processed.').nullable().optional()
 })
 

--- a/lib/resume/actions.ts
+++ b/lib/resume/actions.ts
@@ -37,7 +37,6 @@ export const listResumesForUser = async (): Promise<ResumeListItem[]> => {
 		const data = await api.get<unknown[]>('/resume/')
 		return (data || []).map(item => ResumeListItemSchema.parse(item))
 	} catch (error) {
-		console.log(error)
 		return handleErrors(error, 'list resumes')
 	}
 }

--- a/lib/resume/actions.ts
+++ b/lib/resume/actions.ts
@@ -1,6 +1,13 @@
 'use server'
 
-import {Resume, ResumeMutation, ResumeMutationSchema, ResumeSchema} from '@/lib/resume/types'
+import {
+	Resume,
+	ResumeListItem,
+	ResumeListItemSchema,
+	ResumeMutation,
+	ResumeMutationSchema,
+	ResumeSchema
+} from '@/lib/resume/types'
 import {parseResume} from '@/lib/resume/parser'
 import {api} from '@/lib/config/api-client'
 import {handleErrors} from '@/lib/misc/error-handler'
@@ -18,6 +25,20 @@ export const getResumeFromDB = async (resumeId?: string | 'base'): Promise<Resum
 		return ResumeSchema.parse(data)
 	} catch (error) {
 		return handleErrors(error, 'fetch resume')
+	}
+}
+
+/**
+ * Retrieves all resumes for the current user
+ * GET /resume/
+ */
+export const listResumesForUser = async (): Promise<ResumeListItem[]> => {
+	try {
+		const data = await api.get<unknown[]>('/resume/')
+		return (data || []).map(item => ResumeListItemSchema.parse(item))
+	} catch (error) {
+		console.log(error)
+		return handleErrors(error, 'list resumes')
 	}
 }
 

--- a/lib/resume/key.ts
+++ b/lib/resume/key.ts
@@ -1,1 +1,2 @@
 export const BASE_RESUME_KEYS = ['base-resume']
+export const RESUMES_KEYS = ['resumes']

--- a/lib/resume/queries.ts
+++ b/lib/resume/queries.ts
@@ -1,6 +1,7 @@
 import {queryOptions, useQuery} from '@tanstack/react-query'
-import {BASE_RESUME_KEYS} from '@/lib/resume/key'
-import {getResumeFromDB} from '@/lib/resume/actions'
+import {BASE_RESUME_KEYS, RESUMES_KEYS} from '@/lib/resume/key'
+import {getResumeFromDB, listResumesForUser} from '@/lib/resume/actions'
+import {ResumeListItem} from '@/lib/resume/types'
 
 export const baseResumeQueryOptions = queryOptions({
 	queryKey: BASE_RESUME_KEYS,
@@ -9,3 +10,10 @@ export const baseResumeQueryOptions = queryOptions({
 
 
 export const useBaseResume = () => useQuery(baseResumeQueryOptions)
+
+export const resumesListQueryOptions = queryOptions<ResumeListItem[]>({
+    queryKey: RESUMES_KEYS,
+    queryFn: () => listResumesForUser()
+})
+
+export const useResumes = () => useQuery(resumesListQueryOptions)

--- a/lib/resume/queries.ts
+++ b/lib/resume/queries.ts
@@ -12,8 +12,8 @@ export const baseResumeQueryOptions = queryOptions({
 export const useBaseResume = () => useQuery(baseResumeQueryOptions)
 
 export const resumesListQueryOptions = queryOptions<ResumeListItem[]>({
-    queryKey: RESUMES_KEYS,
-    queryFn: () => listResumesForUser()
+	queryKey: RESUMES_KEYS,
+	queryFn: () => listResumesForUser()
 })
 
 export const useResumes = () => useQuery(resumesListQueryOptions)

--- a/lib/resume/types.ts
+++ b/lib/resume/types.ts
@@ -56,7 +56,8 @@ export const ResumeSchema = z.object({
 	user: UserInfoSchema.describe('The user information associated with the resume.'),
 	job: JobSchema.describe('The job information associated with the resume.'),
 	status: z.string().describe('Indicates if the resume is currently being processed.').nullable().optional(),
-	sections: z.array(ResumeSectionSchema).describe('The sections included in the resume, such as education and experience.')
+	sections: z.array(ResumeSectionSchema).describe('The sections included in the resume, such as education and experience.'),
+	thumbnail: z.string().describe('The thumbnail of the resume.').nullable().optional()
 })
 
 // Infer TypeScript types from the schema
@@ -103,3 +104,36 @@ export const ResumeMutationSchema = z.object({
 })
 
 export type ResumeMutation = z.infer<typeof ResumeMutationSchema>
+
+/**
+ * Lightweight schema for listing resumes for a user
+ */
+export const ResumeListItemSchema = z.discriminatedUnion('base', [
+    z.object({
+        id: z.string(),
+        base: z.literal(true),
+        job: JobSchema.partial({
+            requirements: true,
+            responsibilities: true,
+            benefits: true,
+            status: true
+        }),
+        user: z.string().optional(),
+        status: z.string().nullable().optional(),
+        thumbnail: z.string().nullable().optional()
+    }),
+    z.object({
+        id: z.string(),
+        base: z.literal(false),
+        job: JobSchema.extend({
+            requirements: JobSchema.shape.requirements.optional(),
+            responsibilities: JobSchema.shape.responsibilities.optional(),
+            benefits: JobSchema.shape.benefits.optional()
+        }),
+        user: z.string().optional(),
+        status: z.string().nullable().optional(),
+        thumbnail: z.string().nullable().optional()
+    })
+])
+
+export type ResumeListItem = z.infer<typeof ResumeListItemSchema>

--- a/lib/resume/types.ts
+++ b/lib/resume/types.ts
@@ -109,31 +109,31 @@ export type ResumeMutation = z.infer<typeof ResumeMutationSchema>
  * Lightweight schema for listing resumes for a user
  */
 export const ResumeListItemSchema = z.discriminatedUnion('base', [
-    z.object({
-        id: z.string(),
-        base: z.literal(true),
-        job: JobSchema.partial({
-            requirements: true,
-            responsibilities: true,
-            benefits: true,
-            status: true
-        }),
-        user: z.string().optional(),
-        status: z.string().nullable().optional(),
-        thumbnail: z.string().nullable().optional()
-    }),
-    z.object({
-        id: z.string(),
-        base: z.literal(false),
-        job: JobSchema.extend({
-            requirements: JobSchema.shape.requirements.optional(),
-            responsibilities: JobSchema.shape.responsibilities.optional(),
-            benefits: JobSchema.shape.benefits.optional()
-        }),
-        user: z.string().optional(),
-        status: z.string().nullable().optional(),
-        thumbnail: z.string().nullable().optional()
-    })
+	z.object({
+		id: z.string(),
+		base: z.literal(true),
+		job: JobSchema.partial({
+			requirements: true,
+			responsibilities: true,
+			benefits: true,
+			status: true
+		}),
+		user: z.string().optional(),
+		status: z.string().nullable().optional(),
+		thumbnail: z.string().nullable().optional()
+	}),
+	z.object({
+		id: z.string(),
+		base: z.literal(false),
+		job: JobSchema.extend({
+			requirements: JobSchema.shape.requirements.optional(),
+			responsibilities: JobSchema.shape.responsibilities.optional(),
+			benefits: JobSchema.shape.benefits.optional()
+		}),
+		user: z.string().optional(),
+		status: z.string().nullable().optional(),
+		thumbnail: z.string().nullable().optional()
+	})
 ])
 
 export type ResumeListItem = z.infer<typeof ResumeListItemSchema>


### PR DESCRIPTION
### Issue:
[LET-106 | comp: Display the resume previews with additional details in the dashboard](https://linear.app/letraz/issue/LET-106/comp-display-the-resume-previews-with-additional-details-in-the)

### Description:
Enhancing the user dashboard in the `letraz-client` repository to display visually appealing resume thumbnail previews with relevant details.

### Changes Made:
- Updated Dashboard Resume List Component to accommodate thumbnail previews.
- Implemented data fetching for thumbnails and key resume details.
- Rendered thumbnails with fallback mechanisms and displayed additional resume information.
- Added loading and error states for improved user experience.
- Enabled interactivity for seamless navigation to specific resume pages.

### Closing Note:
This PR enhances user experience by providing visually engaging resume previews with essential details, improving dashboard functionality and usability.