### PR TITLE
LET-140 | bug: Posthog doesn't associate user's email address with waitlist_submitted event

### DIFF
--- a/components/Waitlist.tsx
+++ b/components/Waitlist.tsx
@@ -13,6 +13,7 @@ import {AnimatePresence, motion} from 'motion/react'
 import {toast} from 'sonner'
 import {discordHandle} from '@/config'
 import {useAnalytics} from '@/lib/analytics'
+import posthog from 'posthog-js'
 
 const formSchema = z.object({
 	email: z.string().email({message: 'Please enter a valid email address'})
@@ -37,7 +38,11 @@ const Waitlist = ({className, referrer}: {className?: string, referrer: string |
 		try {
 			setSignedUp(true)
 			await signUpForWaitlist(values.email, referrer)
-			track('waitlist_submitted', {referrer})
+			track('waitlist_submitted', {referrer}, {
+				identify: values.email,
+				set: {email: values.email, referrer: referrer ?? null},
+				setOnce: {first_seen_at: new Date().toISOString()}
+			})
 			form.reset()
 		} catch (error) {
 			setSignedUp(false)


### PR DESCRIPTION
### Issue:
[LET-140 | bug: Posthog doesn't associate user's email address with waitlist_submitted event](https://linear.app/letraz/issue/LET-140/bug-posthog-doesnt-associate-users-email-address-with-waitlist)

### Description:
This pull request addresses the bug where the `waitlist_submitted` event captured in PostHog is not correctly associated with the user's email address.

### Changes Made:
- Added user's email address as a property to the `waitlist_submitted` event in PostHog.
- Updated `letraz-client` code to ensure the email address is included when capturing the `waitlist_submitted` event.
- Verified availability of the `userEmail` variable for capturing the email address.
- Considered early identification of users by email before full signup.
- Implemented error handling to prevent capturing events with empty email properties.

### Closing Note:
This PR is crucial as it enables proper segmentation of waitlist users by email, enhances understanding of user behavior pre-signup, and facilitates targeted outreach campaigns based on initial engagement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved analytics for waitlist sign-ups, capturing user identification and basic metadata (email, referrer, first seen timestamp) on successful submission.
  - Expanded analytics capabilities to support optional identification and property updates per event, enabling more consistent, richer reporting.
  - Standardized event payloads without altering the user-facing submission flow or error handling.
  - No UI changes; users will experience the same waitlist process with enhanced behind-the-scenes tracking for better insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->